### PR TITLE
Add prometheus client to requirements

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -3,3 +3,4 @@ requests==2.32.2
 gunicorn==22.0.0
 flask_cors==4.0.1
 remla24-team8-lib-version==0.3.3
+prometheus-client==0.20.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ markupsafe==2.1.5
     #   werkzeug
 packaging==24.0
     # via gunicorn
+prometheus-client==0.20.0
 remla24-team8-lib-version==0.3.3
 requests==2.32.2
 urllib3==1.26.18


### PR DESCRIPTION
The container crashed because the prometheus client was not added to the requirements.